### PR TITLE
prevent show same images on img tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@
 	angular.module('angular.img', [
 	]).directive('httpSrc', ['$http', function ($http) {
 		return {
+			// do not share scope with sibling img tags and parent
+			// (prevent show same images on img tag)
+			scope: {},
 			link: function ($scope, elem, attrs) {
 				function revokeObjectURL() {
 					if ($scope.objectURL) {


### PR DESCRIPTION
### example codes:

```html
<img http-src="/resource/Board/Controls/ImageFileViewer.ashx?ImageAttachID=8dca-cdb1000510db"/>
<img http-src="/resource/Board/Controls/ImageFileViewer.ashx?ImageAttachID=a703-b06da5f1a697"/>
```

### before fixed
displayed same images by `http-src`
![1](https://cloud.githubusercontent.com/assets/8110371/17812109/a03941cc-6660-11e6-9048-c0beca6e7892.PNG)


### after fixed
gotcha!!!
![2](https://cloud.githubusercontent.com/assets/8110371/17812142/c52a084a-6660-11e6-85fe-8ae1b56052b7.PNG)

